### PR TITLE
🚑️ Fix indexing error on row size too long

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -169,7 +169,12 @@ func getEventStrings(events types.StringEvents) []string {
 	for _, event := range events {
 		for _, attr := range event.Attributes {
 			s := fmt.Sprintf("%s.%s=\"%s\"", event.Type, attr.Key, attr.Value)
-			eventStrings = append(eventStrings, s)
+			if len(s) < 8100 {
+				// Cosmos SDK indeed generate meaninglessly long event strings
+				// (e.g. in IBC client update, hex-encoding the whole header)
+				// These event strings are useless and can't be handled by Postgres GIN index
+				eventStrings = append(eventStrings, s)
+			}
 		}
 	}
 	return eventStrings


### PR DESCRIPTION
Fixing `index row requires 40824 bytes, maximum size is 8191 (SQLSTATE 54000)` error by removing extremely long event strings