### PR TITLE
Feat/iscn prefix

### DIFF
--- a/db/extract.go
+++ b/db/extract.go
@@ -131,7 +131,7 @@ func GetMetaHeight(conn *pgxpool.Conn, key string) (int64, error) {
 	return height, err
 }
 
-func (batch *Batch) InsertISCN(insert ISCNInsert) {
+func (batch *Batch) InsertIscn(insert IscnInsert) {
 	stakeholderIDs := []string{}
 	stakeholderNames := []string{}
 	stakeholderRawJSONs := [][]byte{}

--- a/db/iscn.go
+++ b/db/iscn.go
@@ -20,13 +20,14 @@ func QueryIscn(conn *pgxpool.Conn, query IscnQuery, page PageRequest) (IscnRespo
 			ON id = iscn_pid
 			WHERE
 				($1 = '' OR iscn_id = $1)
-				AND ($2 = '' OR owner = $2)
-				AND ($3::text[] IS NULL OR keywords @> $3)
-				AND ($4::text[] IS NULL OR fingerprints @> $4)
-				AND ($5 = '' OR sid = $5)
-				AND ($6 = '' OR sname = $6)
-				AND ($7 = 0 OR id > $7)
-				AND ($8 = 0 OR id < $8)
+				AND ($2 = '' OR iscn_id_prefix = $2)
+				AND ($3 = '' OR owner = $3)
+				AND ($4::text[] IS NULL OR keywords @> $4)
+				AND ($5::text[] IS NULL OR fingerprints @> $5)
+				AND ($6 = '' OR sid = $6)
+				AND ($7 = '' OR sname = $7)
+				AND ($8 = 0 OR id > $8)
+				AND ($9 = 0 OR id < $9)
 			ORDER BY id %s, timestamp
 			LIMIT %d;
 		`, page.Order(), MAX_LIMIT)
@@ -36,7 +37,8 @@ func QueryIscn(conn *pgxpool.Conn, query IscnQuery, page PageRequest) (IscnRespo
 
 	rows, err := conn.Query(
 		ctx, sql,
-		query.IscnId, query.Owner, query.Keywords, query.Fingerprints, query.StakeholderId, query.StakeholderName,
+		query.IscnId, query.IscnIdPrefix, query.Owner, query.Keywords,
+		query.Fingerprints, query.StakeholderId, query.StakeholderName,
 		page.After(), page.Before(),
 	)
 	if err != nil {
@@ -96,6 +98,7 @@ func QueryIscnSearch(conn *pgxpool.Conn, term string, pagination PageRequest) (I
 				WHERE
 					(
 						iscn_id = $1
+						OR iscn_id_prefix = $1
 						OR owner = $1
 						OR keywords @> $2::text[]
 						OR fingerprints @> $2::text[]

--- a/db/iscn_test.go
+++ b/db/iscn_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestISCNCombineQuery(t *testing.T) {
+func TestIscnCombineQuery(t *testing.T) {
 	conn, err := AcquireFromPool(pool)
 	if err != nil {
 		log.Fatalln(err)
@@ -14,83 +14,83 @@ func TestISCNCombineQuery(t *testing.T) {
 
 	tables := []struct {
 		name string
-		ISCNQuery
+		IscnQuery
 		hasResult bool
 	}{
 		{
 			"iscn_id",
-			ISCNQuery{
-				IscnID: "iscn://likecoin-chain/laa5PLHfQO2eIfiPB2-ZnFLQrmSXOgL-NvoxyBTXHvY/1",
+			IscnQuery{
+				IscnId: "iscn://likecoin-chain/laa5PLHfQO2eIfiPB2-ZnFLQrmSXOgL-NvoxyBTXHvY/1",
 			},
 			true,
 		},
 		{
 			"stakeholder_name",
-			ISCNQuery{
+			IscnQuery{
 				StakeholderName: "kin",
 			},
 			true,
 		},
 		{
 			"keyword",
-			ISCNQuery{
+			IscnQuery{
 				Keywords: []string{"LikeCoin"},
 			},
 			true,
 		},
 		{
 			"keywords",
-			ISCNQuery{
+			IscnQuery{
 				Keywords: []string{"superlike", "civicliker"},
 			},
 			true,
 		},
 		{
 			"John Perry Barlow",
-			ISCNQuery{
+			IscnQuery{
 				StakeholderName: "John Perry Barlow",
 			},
 			true,
 		},
 		{
 			"Apple Daily",
-			ISCNQuery{
+			IscnQuery{
 				StakeholderName: "Apple Daily",
 			},
 			true,
 		},
 		{
 			"Apple Daily ID",
-			ISCNQuery{
-				StakeholderID: "Apple Daily",
+			IscnQuery{
+				StakeholderId: "Apple Daily",
 			},
 			true,
 		},
 		{
 			"Next Digital Ltd",
-			ISCNQuery{
-				StakeholderID: "Next Digital Ltd",
+			IscnQuery{
+				StakeholderId: "Next Digital Ltd",
 			},
 			true,
 		},
 		{
 			"《明報》",
-			ISCNQuery{
+			IscnQuery{
 				StakeholderName: "《明報》",
 			},
 			true,
 		},
 		{
 			"depub.space",
-			ISCNQuery{
+			IscnQuery{
 				StakeholderName: "depub.space",
 			},
 			true,
 		},
 		{
 			"depub.space id",
-			ISCNQuery{
-				StakeholderID: "https://depub.SPACE",
+			IscnQuery{
+				StakeholderId: "https://depub.SPACE",
 			},
 			true,
 		},
@@ -103,7 +103,7 @@ func TestISCNCombineQuery(t *testing.T) {
 				Reverse: true,
 			}
 
-			res, err := QueryISCN(conn, v.ISCNQuery, p)
+			res, err := QueryIscn(conn, v.IscnQuery, p)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -115,7 +115,7 @@ func TestISCNCombineQuery(t *testing.T) {
 	}
 }
 
-func TestISCNList(t *testing.T) {
+func TestIscnList(t *testing.T) {
 	conn, err := AcquireFromPool(pool)
 	if err != nil {
 		log.Fatalln(err)
@@ -127,14 +127,14 @@ func TestISCNList(t *testing.T) {
 		Reverse: true,
 	}
 
-	res, err := QueryISCNList(conn, p)
+	res, err := QueryIscnList(conn, p)
 	if err != nil {
 		t.Error(err)
 	}
 	t.Log(len(res.Records))
 }
 
-func TestISCNQueryAll(t *testing.T) {
+func TestIscnQueryAll(t *testing.T) {
 	conn, err := AcquireFromPool(pool)
 	if err != nil {
 		log.Fatalln(err)
@@ -196,7 +196,7 @@ func TestISCNQueryAll(t *testing.T) {
 	for _, v := range tables {
 		t.Run(v.term, func(t *testing.T) {
 			t.Log(v.term)
-			res, err := QueryISCNAll(conn, v.term, p)
+			res, err := QueryIscnSearch(conn, v.term, p)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -207,7 +207,7 @@ func TestISCNQueryAll(t *testing.T) {
 	}
 }
 
-func TestISCNPagination(t *testing.T) {
+func TestIscnPagination(t *testing.T) {
 	conn, err := AcquireFromPool(pool)
 	if err != nil {
 		log.Fatalln(err)
@@ -226,7 +226,7 @@ func TestISCNPagination(t *testing.T) {
 		}: 1290,
 	}
 	for p, a := range table {
-		res, err := QueryISCNList(conn, p)
+		res, err := QueryIscnList(conn, p)
 		if err != nil {
 			t.Error(err)
 		}

--- a/db/iscn_test.go
+++ b/db/iscn_test.go
@@ -25,6 +25,13 @@ func TestIscnCombineQuery(t *testing.T) {
 			true,
 		},
 		{
+			"iscn_id",
+			IscnQuery{
+				IscnIdPrefix: "iscn://likecoin-chain/laa5PLHfQO2eIfiPB2-ZnFLQrmSXOgL-NvoxyBTXHvY",
+			},
+			true,
+		},
+		{
 			"stakeholder_name",
 			IscnQuery{
 				StakeholderName: "kin",
@@ -170,6 +177,10 @@ func TestIscnQueryAll(t *testing.T) {
 		},
 		{
 			term:   "iscn://likecoin-chain/zGY8c7obhwx7qa4Ro763kr6lvBCZ4SIMagYRXRXYSnM/1",
+			length: 1,
+		},
+		{
+			term:   "iscn://likecoin-chain/zGY8c7obhwx7qa4Ro763kr6lvBCZ4SIMagYRXRXYSnM",
 			length: 1,
 		},
 		{

--- a/db/types.go
+++ b/db/types.go
@@ -52,12 +52,23 @@ type ISCNInsert struct {
 }
 
 type ISCNQuery struct {
-	IscnID          string
-	Owner           string
-	Keywords        []string
-	Fingerprints    []string
-	StakeholderID   string
-	StakeholderName string
+	IscnID          string   `form:"iscn_id"`
+	IscnIDPrefix    string   `form:"iscn_id_prefix"`
+	Owner           string   `form:"owner"`
+	Keywords        []string `form:"keyword"`
+	Fingerprints    []string `form:"fingerprint"`
+	StakeholderID   string   `form:"stakeholder.id"`
+	StakeholderName string   `form:"stakeholder.name"`
+}
+
+func (q ISCNQuery) Empty() bool {
+	return q.IscnID == "" &&
+		q.IscnIDPrefix == "" &&
+		q.Owner == "" &&
+		len(q.Keywords) == 0 &&
+		len(q.Fingerprints) == 0 &&
+		q.StakeholderID == "" &&
+		q.StakeholderName == ""
 }
 
 type NftClass struct {

--- a/db/types.go
+++ b/db/types.go
@@ -35,7 +35,7 @@ func (e *Entity) UnmarshalJSON(data []byte) (err error) {
 	return nil
 }
 
-type ISCNInsert struct {
+type IscnInsert struct {
 	Iscn         string
 	IscnPrefix   string
 	Version      int
@@ -51,23 +51,23 @@ type ISCNInsert struct {
 	Data         []byte
 }
 
-type ISCNQuery struct {
-	IscnID          string   `form:"iscn_id"`
-	IscnIDPrefix    string   `form:"iscn_id_prefix"`
+type IscnQuery struct {
+	IscnId          string   `form:"iscn_id"`
+	IscnIdPrefix    string   `form:"iscn_id_prefix"`
 	Owner           string   `form:"owner"`
 	Keywords        []string `form:"keyword"`
 	Fingerprints    []string `form:"fingerprint"`
-	StakeholderID   string   `form:"stakeholder.id"`
+	StakeholderId   string   `form:"stakeholder.id"`
 	StakeholderName string   `form:"stakeholder.name"`
 }
 
-func (q ISCNQuery) Empty() bool {
-	return q.IscnID == "" &&
-		q.IscnIDPrefix == "" &&
+func (q IscnQuery) Empty() bool {
+	return q.IscnId == "" &&
+		q.IscnIdPrefix == "" &&
 		q.Owner == "" &&
 		len(q.Keywords) == 0 &&
 		len(q.Fingerprints) == 0 &&
-		q.StakeholderID == "" &&
+		q.StakeholderId == "" &&
 		q.StakeholderName == ""
 }
 
@@ -151,17 +151,17 @@ type PageResponse struct {
 	Count   int    `json:"count,omitempty"`
 }
 
-type ISCNResponse struct {
-	Records    []ISCNResponseRecord `json:"records"`
+type IscnResponse struct {
+	Records    []iscnResponseRecord `json:"records"`
 	Pagination PageResponse         `json:"pagination"`
 }
 
-type ISCNResponseRecord struct {
+type iscnResponseRecord struct {
 	Ipld string           `json:"ipld,omitempty"`
-	Data ISCNResponseData `json:"data,omitempty"`
+	Data iscnResponseData `json:"data,omitempty"`
 }
 
-type ISCNResponseData struct {
+type iscnResponseData struct {
 	Id                  string          `json:"@id"`
 	RecordTimestamp     time.Time       `json:"recordTimestamp"`
 	Owner               string          `json:"owner"`

--- a/examples/iscn.md
+++ b/examples/iscn.md
@@ -11,7 +11,10 @@ export ENDPOINT="http://localhost:8997"
 ## Query by ISCN ID
 
 ```bash
+# By ID
 curl $ENDPOINT/iscn/records?iscn_id=iscn://likecoin-chain/laa5PLHfQO2eIfiPB2-ZnFLQrmSXOgL-NvoxyBTXHvY/1
+# By Prefix
+curl $ENDPOINT/iscn/records?iscn_id_prefix=iscn://likecoin-chain/laa5PLHfQO2eIfiPB2-ZnFLQrmSXOgL-NvoxyBTXHvY
 ```
 
 ## Query by owner
@@ -26,28 +29,28 @@ curl $ENDPOINT/iscn/records?owner=cosmos18q3dzavq7c6njw92344rf8ejpyqxqwzvy7ef50&
 curl $ENDPOINT/iscn/records?fingerprint=ipfs://QmRzbij1C7224PNiw4cNBt1NzH7SbArkGjJGVb3y4Xpiw8
 ```
 
-## Query by keywords
+## Query by keyword
 
 ```bash
-curl $ENDPOINT/iscn/records?keywords=decentralizehk&keywords=DAO
+curl $ENDPOINT/iscn/records?keyword=decentralizehk&keyword=DAO
 ```
 
-## Query by stakeholders entity ID
+## Query by stakeholders ID
 
 ```bash
-curl $ENDPOINT/iscn/records?stakeholders.entity.id=did:cosmos:1vvxaklu364sejxe9tdwkg87aanejf8v6mwdu82
+curl $ENDPOINT/iscn/records?stakeholder.id=did:cosmos:1vvxaklu364sejxe9tdwkg87aanejf8v6mwdu82
 ```
 
-## Query by stakeholders entity name
+## Query by stakeholders name
 
 ```bash
-curl $ENDPOINT/iscn/records?stakeholders.entity.name=joshkiu
+curl $ENDPOINT/iscn/records?stakeholder.name=joshkiu
 ```
 
 ## Compound query
 
 ```bash
-curl $ENDPOINT/iscn/records?owner=cosmos1ykkpc0dnetfsya88f5nrdd7p57kplaw8sva6pj&keywords=香港&limit=5&page=2
+curl $ENDPOINT/iscn/records?owner=cosmos1ykkpc0dnetfsya88f5nrdd7p57kplaw8sva6pj&keyword=香港&limit=5&page=2
 ```
 
 ## Example response
@@ -56,78 +59,48 @@ curl $ENDPOINT/iscn/records?owner=cosmos1ykkpc0dnetfsya88f5nrdd7p57kplaw8sva6pj&
 {
   "records": [
     {
-      "ipld": "baguqeeragy7ojsthcjfsqqktqtjpmamrhzrlgtkvglucje3fptqu7thox4qa",
+      "ipld": "baguqeerayhsd7mbhbauudoftlcjqejy2k6zl4xurku3z45sq3hg7ekics5ha",
       "data": {
-        "@context": {
-          "@vocab": "http://iscn.io/",
-          "contentMetadata": {
-            "@context": null
-          },
-          "recordParentIPLD": {
-            "@container": "@index"
-          },
-          "stakeholders": {
-            "@context": {
-              "@vocab": "http://schema.org/",
-              "contributionType": "http://iscn.io/contributionType",
-              "entity": "http://iscn.io/entity",
-              "footprint": "http://iscn.io/footprint",
-              "rewardProportion": "http://iscn.io/rewardProportion"
-            }
-          }
-        },
-        "@id": "iscn://likecoin-chain/cbwJejWH2jUdM4ZsP_Kh5RyN-j_SBovjieroWXY0yRQ/1",
-        "@type": "Record",
+        "@id": "iscn://likecoin-chain/TPtbTpMco5zNmhGCX2U3UCFe4d415eyrXTabYZGm9PE/1",
+        "recordTimestamp": "2021-08-19T04:31:03Z",
+        "owner": "cosmos13f4glvg80zvfrrs7utft5p68pct4mcq7cgpf2p",
+        "recordNotes": "",
         "contentFingerprints": [
-          "hash://sha256/8e6984120afb8ac0f81080cf3e7a38042c472c4deb3e2588480df6e199741c89",
-          "ipfs://QmVpBwQ4J1UY8tThmhRm4HqjiVPZThRyCxcN2iMi1L9rbS",
-          "ar://XbVo9x7qml1-5N1wcbyLzXW-EQcCdWPq7QNmxzn7_-w"
+          "ipfs://QmUnGEozva55C9Z1MLpULh6UXrUDe4Yo3g1K4ZN6ZqzyEs"
         ],
         "contentMetadata": {
+          "@type": "Article",
+          "name": "decentralize：無大台，有共識",
+          "version": 1,
           "@context": "http://schema.org/",
-          "@type": "Photo",
-          "description": "狗，4歲，男性，生性貪吃",
-          "exifInfo": {
-            "ColorSpace": 65535,
-            "ExifImageHeight": 1108,
-            "ExifImageWidth": 1478,
-            "ExifVersion": "2.2",
-            "Format": "image/jpeg",
-            "ImageUniqueID": "4e3fcc68fee70b310000000000000000",
-            "Size": "1108 x 1478 JPEG (191 KB)",
-            "Software": "Picasa"
-          },
-          "keywords": "狗,巴豆",
-          "name": "巴豆",
-          "url": "-",
-          "usageInfo": "-",
-          "version": 1
+          "keywords": "blockchain,DAO,decentralization,decentralizehk",
+          "usageInfo": "ipfs://QmRvpQiiLA8ttSLAXEd5RArmXeG4qWEsKPmrB7KeiLSuE4"
         },
-        "recordNotes": "",
-        "recordTimestamp": "2021-12-06T06:14:26+00:00",
-        "recordVersion": 1,
         "stakeholders": [
           {
-            "contributionType": "http://schema.org/author",
             "entity": {
-              "@id": "did:cosmos:1qv66yzpgg9f8w46zj7gkuk9wd2nrpqmcwdt79j",
-              "description": "",
-              "identifier": [
-                {
-                  "@type": "PropertyValue",
-                  "propertyID": "Cosmos Wallet",
-                  "value": "did:cosmos:1qv66yzpgg9f8w46zj7gkuk9wd2nrpqmcwdt79j"
-                }
-              ],
-              "name": "Auora Huang",
-              "sameAs": [],
-              "url": "https://like.co/aurorahuang22"
+              "id": "https://like.co/undefined",
+              "name": "kin ko"
             },
+            "contributionType": "http://schema.org/author",
+            "rewardProportion": 1
+          },
+          {
+            "entity": {
+              "id": "https://matters.news/",
+              "name": "Matters",
+              "description": "Matters is a decentralized, cryptocurrency driven content creation and discussion platform."
+            },
+            "contributionType": "http://schema.org/publisher",
             "rewardProportion": 1
           }
         ]
       }
     }
-  ]
+  ],
+  "pagination": {
+    "next_key": 2,
+    "count": 1
+  }
 }
 ```

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -10,12 +10,12 @@ import (
 )
 
 var handlers = map[string]db.EventHandler{
-	"create_iscn_record":                           insertISCN,
-	"/likechain.iscn.MsgCreateIscnRecord":          insertISCN,
-	"update_iscn_record":                           insertISCN,
-	"/likechain.iscn.MsgUpdateIscnRecord":          insertISCN,
-	"msg_change_iscn_record_ownership":             transferISCN,
-	"/likechain.iscn.MsgChangeIscnRecordOwnership": transferISCN,
+	"create_iscn_record":                           insertIscn,
+	"/likechain.iscn.MsgCreateIscnRecord":          insertIscn,
+	"update_iscn_record":                           insertIscn,
+	"/likechain.iscn.MsgUpdateIscnRecord":          insertIscn,
+	"msg_change_iscn_record_ownership":             transferIscn,
+	"/likechain.iscn.MsgChangeIscnRecordOwnership": transferIscn,
 	"new_class":                   createNftClass,
 	"update_class":                updateNftClass,
 	"mint_nft":                    mintNft,

--- a/extractor/iscn.go
+++ b/extractor/iscn.go
@@ -32,7 +32,7 @@ func (q iscnData) Marshal() ([]byte, error) {
 	return json.Marshal(q)
 }
 
-func insertISCN(payload db.EventPayload) error {
+func insertIscn(payload db.EventPayload) error {
 	message := payload.Message
 	events := payload.Events
 	var data iscnMessage
@@ -70,11 +70,11 @@ func insertISCN(payload db.EventPayload) error {
 		Ipld:         utils.GetEventsValue(events, "iscn_record", "ipld"),
 		Data:         data.Record,
 	}
-	payload.Batch.InsertISCN(iscn)
+	payload.Batch.InsertIscn(iscn)
 	return nil
 }
 
-func transferISCN(payload db.EventPayload) error {
+func transferIscn(payload db.EventPayload) error {
 	events := payload.Events
 	sender := utils.GetEventsValue(events, "message", "sender")
 	iscnId := utils.GetEventsValue(events, "iscn_record", "iscn_id")

--- a/extractor/iscn.go
+++ b/extractor/iscn.go
@@ -55,7 +55,7 @@ func insertISCN(payload db.EventPayload) error {
 		parsedStakeholder.Data = stakeholderRawJSON
 		stakeholders = append(stakeholders, parsedStakeholder)
 	}
-	iscn := db.ISCNInsert{
+	iscn := db.IscnInsert{
 		Iscn:         utils.GetEventsValue(events, "iscn_record", "iscn_id"),
 		IscnPrefix:   utils.GetEventsValue(events, "iscn_record", "iscn_id_prefix"),
 		Version:      getIscnVersion(utils.GetEventsValue(events, "iscn_record", "iscn_id")),

--- a/rest/iscn.go
+++ b/rest/iscn.go
@@ -3,24 +3,21 @@ package rest
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/likecoin/likecoin-chain-tx-indexer/db"
-	"github.com/likecoin/likecoin-chain-tx-indexer/logger"
 )
 
-func handleISCN(c *gin.Context) {
+func handleIscn(c *gin.Context) {
 	q := c.Request.URL.Query()
 	if q.Get("q") != "" {
-		handleISCNSearch(c)
+		handleIscnSearch(c)
 		return
 	}
 
-	var form db.ISCNQuery
+	var form db.IscnQuery
 
 	if err := c.ShouldBindQuery(&form); err != nil {
 		c.AbortWithStatusJSON(400, gin.H{"error": err.Error()})
 		return
 	}
-
-	logger.L.Debugw("", "form", form)
 
 	p, err := getPagination(c)
 	if err != nil {
@@ -29,11 +26,11 @@ func handleISCN(c *gin.Context) {
 	}
 
 	conn := getConn(c)
-	var res db.ISCNResponse
+	var res db.IscnResponse
 	if form.Empty() {
-		res, err = db.QueryISCNList(conn, p)
+		res, err = db.QueryIscnList(conn, p)
 	} else {
-		res, err = db.QueryISCN(conn, form, p)
+		res, err = db.QueryIscn(conn, form, p)
 	}
 	if err != nil {
 		c.AbortWithStatusJSON(500, gin.H{"error": err.Error()})
@@ -43,7 +40,7 @@ func handleISCN(c *gin.Context) {
 	c.JSON(200, res)
 }
 
-func handleISCNSearch(c *gin.Context) {
+func handleIscnSearch(c *gin.Context) {
 	q := c.Request.URL.Query()
 	p, err := getPagination(c)
 	if err != nil {
@@ -56,7 +53,7 @@ func handleISCNSearch(c *gin.Context) {
 		return
 	}
 	conn := getConn(c)
-	res, err := db.QueryISCNAll(conn, term, p)
+	res, err := db.QueryIscnSearch(conn, term, p)
 	if err != nil {
 		c.AbortWithStatusJSON(500, gin.H{"error": err.Error()})
 		return

--- a/rest/iscn_test.go
+++ b/rest/iscn_test.go
@@ -10,107 +10,126 @@ import (
 
 func TestISCNCombine(t *testing.T) {
 	table := []struct {
+		name    string
 		query   string
 		status  int
 		length  int
 		contain []string
 	}{
 		{
+			name:  "iscn_id",
 			query: "iscn_id=iscn://likecoin-chain/laa5PLHfQO2eIfiPB2-ZnFLQrmSXOgL-NvoxyBTXHvY/1",
 		},
 		{
+			name:  "owner",
 			query: "owner=cosmos1qv66yzpgg9f8w46zj7gkuk9wd2nrpqmcwdt79j",
 		},
 		{
+			name:  "fingerprint",
 			query: "fingerprint=hash://sha256/8e6984120afb8ac0f81080cf3e7a38042c472c4deb3e2588480df6e199741c89",
 		},
 		{
+			name:  "empty",
 			query: "",
 		},
 		{
+			name:  "limit",
 			query: "limit=15",
 		},
 		{
-			query:  "keywords=DAO&limit=5",
+			name:   "keyword",
+			query:  "keyword=DAO&limit=5",
 			length: 5,
 		},
 		{
-			query: "keywords=Cyberspace&keywords=EFF&limit=5",
+			name:  "multiple-keywords",
+			query: "keyword=Cyberspace&keyword=EFF&limit=5",
 		},
 		{
-			query:  "keywords=香港&owner=cosmos1ykkpc0dnetfsya88f5nrdd7p57kplaw8sva6pj&limit=5",
+			name:   "keyword & owner",
+			query:  "keyword=香港&owner=cosmos1ykkpc0dnetfsya88f5nrdd7p57kplaw8sva6pj&limit=5",
 			length: 5,
 		},
 		{
-			query: "q=香港&limit=15",
-		},
-		{
-			query:   "stakeholders.entity.name=John+Perry+Barlow",
+			name:    "stakeholder name",
+			query:   "stakeholder.name=John+Perry+Barlow",
 			length:  1,
 			contain: []string{"John Perry Barlow"},
 		},
 		{
-			query:   "stakeholders.entity.name=Apple+Daily&limit=10",
+			name:    "Apple Daily",
+			query:   "stakeholder.name=Apple+Daily&limit=10",
 			length:  10,
 			contain: []string{"Apple Daily"},
 		},
 		{
+			name:    "search by iscn_id",
 			query:   "q=iscn://likecoin-chain/laa5PLHfQO2eIfiPB2-ZnFLQrmSXOgL-NvoxyBTXHvY/1",
 			contain: []string{"iscn://likecoin-chain/laa5PLHfQO2eIfiPB2-ZnFLQrmSXOgL-NvoxyBTXHvY/1"},
 		},
 		{
+			name:   "search by keyword",
+			query:  "q=香港&limit=5",
+			length: 5,
+		},
+		{
+			name:    "search by owner",
 			query:   "q=cosmos1qv66yzpgg9f8w46zj7gkuk9wd2nrpqmcwdt79j",
 			contain: []string{"cosmos1qv66yzpgg9f8w46zj7gkuk9wd2nrpqmcwdt79j"},
 		},
 		{
+			name:    "search by fingerprint",
 			query:   "q=hash://sha256/8e6984120afb8ac0f81080cf3e7a38042c472c4deb3e2588480df6e199741c89",
 			contain: []string{"hash://sha256/8e6984120afb8ac0f81080cf3e7a38042c472c4deb3e2588480df6e199741c89"},
 		},
 		{
+			name:    "LikeCoin",
 			query:   "q=LikeCoin",
 			contain: []string{"LikeCoin"},
 		},
 	}
 	for _, v := range table {
-		req := httptest.NewRequest(
-			"GET",
-			fmt.Sprintf("%s?%s",
-				ISCN_ENDPOINT, v.query),
-			nil,
-		)
-		res, body := request(req)
-		if v.status == 0 {
-			v.status = 200
-		}
-		if res.StatusCode != v.status {
-			t.Fatalf("expect %d, got %d\n%s\n%s", v.status, res.StatusCode, v.query, body)
-		}
-		if res.StatusCode != 200 {
-			continue
-		}
-		var records struct {
-			Records []json.RawMessage
-		}
-
-		if err := json.Unmarshal([]byte(body), &records); err != nil {
-			t.Fatal(err)
-		}
-		if len(records.Records) == 0 {
-			t.Errorf("No response, %s", body)
-			continue
-		}
-		if v.length != 0 && len(records.Records) != v.length {
-			t.Errorf("Length should be %d, got %d.\n%s\n", v.length, len(records.Records), v.query)
-		}
-		for _, record := range records.Records {
-			if v.contain != nil {
-				for _, s := range v.contain {
-					if !strings.Contains(string(record), s) {
-						t.Errorf("record should contain %s, but not found: %s", s, string(record))
-					}
-				}
+		t.Run(v.name, func(t *testing.T) {
+			req := httptest.NewRequest(
+				"GET",
+				fmt.Sprintf("%s?%s",
+					ISCN_ENDPOINT, v.query),
+				nil,
+			)
+			res, body := request(req)
+			if v.status == 0 {
+				v.status = 200
+			}
+			if res.StatusCode != v.status {
+				t.Fatalf("expect %d, got %d\n%s\n%s", v.status, res.StatusCode, v.query, body)
+			}
+			if res.StatusCode != 200 {
+				return
+			}
+			var records struct {
+				Records []json.RawMessage
 			}
 
-		}
+			if err := json.Unmarshal([]byte(body), &records); err != nil {
+				t.Fatal(err)
+			}
+			if len(records.Records) == 0 {
+				t.Fatalf("No response, %s", body)
+				return
+			}
+			if v.length != 0 && len(records.Records) != v.length {
+				t.Errorf("Length should be %d, got %d.\n%s\n", v.length, len(records.Records), v.query)
+			}
+			for _, record := range records.Records {
+				if v.contain != nil {
+					for _, s := range v.contain {
+						if !strings.Contains(string(record), s) {
+							t.Errorf("record should contain %s, but not found: %s", s, string(record))
+						}
+					}
+				}
+
+			}
+		})
 	}
 }

--- a/rest/router.go
+++ b/rest/router.go
@@ -52,7 +52,7 @@ func getRouter(pool *pgxpool.Pool) *gin.Engine {
 		analysis.GET("/owner-count", handleNftOwnerCount)
 		analysis.GET("/owners", handleNftOwnerList)
 	}
-	router.GET(ISCN_ENDPOINT, handleISCN)
+	router.GET(ISCN_ENDPOINT, handleIscn)
 	router.GET("/txs", handleAminoTxsSearch)
 	router.GET(STARGATE_ENDPOINT, handleStargateTxsSearch)
 	router.GET(LATEST_HEIGHT_ENDPOINT, handleLatestHeight)


### PR DESCRIPTION
**BUMP CHANGES:**
Rename query parameter for consistency
/iscn/records
+ stakeholders.entity.id -> stakeholder.id
+ stakeholders.entity.name -> stakeholder.name
+ keywords -> keyword

## Main changes
+ Add iscn_id_prefix support in iscn query and search
+ Refactor iscn query parsing using gin binding
+ Rename types & functions