### PR TITLE
Fix extractor off-by-one issue

### DIFF
--- a/db/schema/v005.sql
+++ b/db/schema/v005.sql
@@ -1,0 +1,3 @@
+UPDATE meta SET height = height - 1 WHERE id = 'extractor_v1';
+
+UPDATE meta SET height = 5 WHERE id = 'schema_version';

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -50,7 +50,7 @@ func Run(pool *pgxpool.Pool) chan<- int64 {
 			}
 			if finished {
 				height := <-trigger
-				logger.L.Infof("Extractor: trigger by poller, sync to %d", height)
+				logger.L.Infof("Extractor: trigger by poller on height %d", height)
 			}
 		}
 	}()


### PR DESCRIPTION
This issue causes extractor to extract events only after another block with tx is created on the chain.
On mainnet, since nearly every block has tx, it is not a big issue (only ~1 block delay).
On testnet, since there is nearly no tx, this causes a huge delay before extractors (and related APIs) update.

Note that this changes the scanning condition, so we need to be careful before deploying, otherwise we may permanently miss extractor data for one block (the "delayed" block).
May need more code on the "migration" process.