### PR TITLE
Remove the iscn_id_prefix_or_account checking from NFT class API

### DIFF
--- a/rest/nft.go
+++ b/rest/nft.go
@@ -12,10 +12,6 @@ func handleNftClass(c *gin.Context) {
 		c.AbortWithStatusJSON(400, gin.H{"error": err.Error()})
 		return
 	}
-	if q.IscnIdPrefix == "" && q.Account == "" {
-		c.AbortWithStatusJSON(400, gin.H{"error": "iscn_id_prefix or account is required"})
-		return
-	}
 	p, err := getPagination(c)
 	if err != nil {
 		c.AbortWithStatusJSON(400, gin.H{"error": err})


### PR DESCRIPTION
After this PR, users may use the indexer API like this to list the latest NFT classes: `/likechain/likenft/v1/class?reverse=true`