### PR TITLE
Add `pagination.` prefix to pagination params in API requests

### DIFF
--- a/db/nft.go
+++ b/db/nft.go
@@ -64,7 +64,7 @@ func GetClasses(conn *pgxpool.Conn, q QueryClassRequest, p PageRequest) (QueryCl
 	return res, nil
 }
 
-func GetClassesRanking(conn *pgxpool.Conn, q QueryRankingRequest) (QueryRankingResponse, error) {
+func GetClassesRanking(conn *pgxpool.Conn, q QueryRankingRequest, p PageRequest) (QueryRankingResponse, error) {
 	sql := `
 	SELECT c.class_id, c.name, c.description, c.symbol, c.uri, c.uri_hash,
 	c.config, c.metadata, c.price,
@@ -95,7 +95,7 @@ func GetClassesRanking(conn *pgxpool.Conn, q QueryRankingRequest) (QueryRankingR
 	defer cancel()
 
 	rows, err := conn.Query(ctx, sql, q.IncludeOwner, q.IgnoreList,
-		q.Limit, q.Creator, q.Type, q.StakeholderId, q.StakeholderName,
+		p.Limit, q.Creator, q.Type, q.StakeholderId, q.StakeholderName,
 		q.Collector, q.After, q.Before)
 	if err != nil {
 		logger.L.Errorw("Failed to query nft class ranking", "error", err, "q", q)
@@ -251,7 +251,7 @@ func GetNftEvents(conn *pgxpool.Conn, q QueryEventsRequest, p PageRequest) (Quer
 	return res, nil
 }
 
-func GetCollector(conn *pgxpool.Conn, q QueryCollectorRequest) (res QueryCollectorResponse, err error) {
+func GetCollector(conn *pgxpool.Conn, q QueryCollectorRequest, p PageRequest) (res QueryCollectorResponse, err error) {
 	sql := `
 	SELECT owner, sum(count) as total,
 		array_agg(json_build_object(
@@ -275,7 +275,7 @@ func GetCollector(conn *pgxpool.Conn, q QueryCollectorRequest) (res QueryCollect
 	ctx, cancel := GetTimeoutContext()
 	defer cancel()
 
-	rows, err := conn.Query(ctx, sql, q.Creator, q.Offset, q.Limit, q.IgnoreList)
+	rows, err := conn.Query(ctx, sql, q.Creator, p.Offset, p.Limit, q.IgnoreList)
 	if err != nil {
 		logger.L.Errorw("Failed to query collectors", "error", err, "q", q)
 		err = fmt.Errorf("query supporters error: %w", err)
@@ -292,7 +292,7 @@ func GetCollector(conn *pgxpool.Conn, q QueryCollectorRequest) (res QueryCollect
 	return
 }
 
-func GetCreators(conn *pgxpool.Conn, q QueryCreatorRequest) (res QueryCreatorResponse, err error) {
+func GetCreators(conn *pgxpool.Conn, q QueryCreatorRequest, p PageRequest) (res QueryCreatorResponse, err error) {
 	sql := `
 	SELECT owner, sum(count) as total,
 		array_agg(json_build_object(
@@ -316,7 +316,7 @@ func GetCreators(conn *pgxpool.Conn, q QueryCreatorRequest) (res QueryCreatorRes
 	ctx, cancel := GetTimeoutContext()
 	defer cancel()
 
-	rows, err := conn.Query(ctx, sql, q.Collector, q.Offset, q.Limit, q.IgnoreList)
+	rows, err := conn.Query(ctx, sql, q.Collector, p.Offset, p.Limit, q.IgnoreList)
 	if err != nil {
 		logger.L.Errorw("Failed to query creators", "error", err, "q", q)
 		err = fmt.Errorf("query creators error: %w", err)

--- a/db/types.go
+++ b/db/types.go
@@ -120,10 +120,10 @@ func (n *NftEvent) Attach(payload EventPayload) {
 }
 
 type PageRequest struct {
-	Key     uint64 `form:"key"`
-	Limit   int    `form:"limit,default=100" binding:"gte=1,lte=100"`
-	Reverse bool   `form:"reverse"`
-	Offset  uint64 `form:"offset"`
+	Key     uint64 `form:"pagination.key"`
+	Limit   int    `form:"pagination.limit,default=100" binding:"gte=1,lte=100"`
+	Reverse bool   `form:"pagination.reverse"`
+	Offset  uint64 `form:"pagination.offset"`
 }
 
 func (p *PageRequest) After() uint64 {

--- a/db/types.go
+++ b/db/types.go
@@ -119,6 +119,13 @@ func (n *NftEvent) Attach(payload EventPayload) {
 	n.TxHash = payload.TxHash
 }
 
+type LegacyPageRequest struct {
+	Key     uint64 `form:"key"`
+	Limit   int    `form:"limit,default=100" binding:"gte=1,lte=100"`
+	Reverse bool   `form:"reverse"`
+	Offset  uint64 `form:"offset"`
+}
+
 type PageRequest struct {
 	Key     uint64 `form:"pagination.key"`
 	Limit   int    `form:"pagination.limit,default=100" binding:"gte=1,lte=100"`
@@ -243,7 +250,6 @@ type QueryRankingRequest struct {
 	Before          int64    `form:"before"`
 	IncludeOwner    bool     `form:"include_owner"`
 	IgnoreList      []string `form:"ignore_list"`
-	PageRequest
 }
 
 type QueryRankingResponse struct {
@@ -259,7 +265,6 @@ type NftClassRankingResponse struct {
 type QueryCollectorRequest struct {
 	Creator    string   `form:"creator"`
 	IgnoreList []string `form:"ignore_list"`
-	PageRequest
 }
 
 type QueryCollectorResponse struct {
@@ -270,7 +275,6 @@ type QueryCollectorResponse struct {
 type QueryCreatorRequest struct {
 	Collector  string   `form:"collector"`
 	IgnoreList []string `form:"ignore_list"`
-	PageRequest
 }
 
 type QueryCreatorResponse struct {

--- a/rest/nft.go
+++ b/rest/nft.go
@@ -104,9 +104,14 @@ func handleNftRanking(c *gin.Context) {
 		c.AbortWithStatusJSON(400, gin.H{"error": err.Error()})
 		return
 	}
+	p, err := getPagination(c)
+	if err != nil {
+		c.AbortWithStatusJSON(400, gin.H{"error": err})
+		return
+	}
 
 	conn := getConn(c)
-	res, err := db.GetClassesRanking(conn, q)
+	res, err := db.GetClassesRanking(conn, q, p)
 	if err != nil {
 		c.AbortWithStatusJSON(500, gin.H{"error": err.Error()})
 		return
@@ -121,10 +126,15 @@ func handleNftCollectors(c *gin.Context) {
 		c.AbortWithStatusJSON(400, gin.H{"error": "invalid inputs: " + err.Error()})
 		return
 	}
+	p, err := getPagination(c)
+	if err != nil {
+		c.AbortWithStatusJSON(400, gin.H{"error": err})
+		return
+	}
 
 	conn := getConn(c)
 
-	res, err := db.GetCollector(conn, form)
+	res, err := db.GetCollector(conn, form, p)
 	if err != nil {
 		c.AbortWithStatusJSON(500, gin.H{"error": err.Error()})
 		return
@@ -139,10 +149,15 @@ func handleNftCreators(c *gin.Context) {
 		c.AbortWithStatusJSON(400, gin.H{"error": "invalid inputs: " + err.Error()})
 		return
 	}
+	p, err := getPagination(c)
+	if err != nil {
+		c.AbortWithStatusJSON(400, gin.H{"error": err})
+		return
+	}
 
 	conn := getConn(c)
 
-	res, err := db.GetCreators(conn, form)
+	res, err := db.GetCreators(conn, form, p)
 	if err != nil {
 		c.AbortWithStatusJSON(500, gin.H{"error": err.Error()})
 		return

--- a/rest/util.go
+++ b/rest/util.go
@@ -118,6 +118,19 @@ func getPool(c *gin.Context) *pgxpool.Pool {
 
 func getPagination(c *gin.Context) (p db.PageRequest, err error) {
 	p = db.PageRequest{}
-	err = c.ShouldBindQuery(&p)
+	for _, key := range []string{"pagination.key", "pagination.limit", "pagination.reverse", "pagination.offset"} {
+		if c.Query(key) != "" {
+			err = c.ShouldBindQuery(&p)
+			return p, err
+		}
+	}
+	// there is no `pagination.xxx` query, then we fall back to legacy keys
+	// everything is in deafult, so we scan
+	legacy := db.LegacyPageRequest{}
+	err = c.ShouldBindQuery(&legacy)
+	p.Key = legacy.Key
+	p.Limit = legacy.Limit
+	p.Offset = legacy.Offset
+	p.Reverse = legacy.Reverse
 	return p, err
 }


### PR DESCRIPTION
This breaks the old behavior (without `pagination.` prefix). Supporting both would be a little bit complicated, as I found no support in Gin for multiple names for the same field.