### PR TITLE
✨ Return `pagination.total` in `/collector` and `/creator` endpoints

### DIFF
--- a/db/nft.go
+++ b/db/nft.go
@@ -356,7 +356,7 @@ func GetCreators(conn *pgxpool.Conn, q QueryCreatorRequest, p PageRequest) (res 
 
 	rows, err := conn.Query(ctx, sql, collectorVariations, p.Offset, p.Limit, ignoreListVariations, q.AllIscnVersions)
 	if err != nil {
-		logger.L.Errorw("ailed to query creators", "error", err, "q", q)
+		logger.L.Errorw("failed to query creators", "error", err, "q", q)
 		err = fmt.Errorf("query creators error: %w", err)
 		return
 	}

--- a/db/types.go
+++ b/db/types.go
@@ -160,6 +160,7 @@ func (p *PageRequest) Order() Order {
 type PageResponse struct {
 	NextKey uint64 `json:"next_key,omitempty"`
 	Count   int    `json:"count,omitempty"`
+	Total   int    `json:"total,omitempty"`
 }
 
 type IscnResponse struct {


### PR DESCRIPTION
- Add an omissible field `Total` in type `Pagination`.
- Get the total row count from the original query.
- Note that for performance concern, `pagination.total` is acquired from the original query with `OFFSET` but not another aggregation query, it will be `nil` if the given `OFFSET` value is greater than the actual total row count.