### PR TITLE
Embed class data in NFT query response

### DIFF
--- a/db/nft_test.go
+++ b/db/nft_test.go
@@ -229,12 +229,36 @@ func TestQueryNftByOwner(t *testing.T) {
 		query := QueryNftRequest{Owner: testCase.owner}
 		res, err := GetNfts(Conn, query, p)
 		if err != nil {
-			t.Errorf("test case #%02d (owner = %s): GetNfts returned error: %#v", i, testCase.owner, err)
+			t.Errorf("test case #%02d (owner = %s, ExpandClasses = false): GetNfts returned error: %#v", i, testCase.owner, err)
 			continue
 		}
 		if len(res.Nfts) != testCase.count {
-			t.Errorf("test case #%02d (owner = %s): expect len(res.Nfts) = %d, got %d. results = %#v", i, testCase.owner, testCase.count, len(res.Nfts), res.Nfts)
+			t.Errorf("test case #%02d (owner = %s, ExpandClasses = false): expect len(res.Nfts) = %d, got %d. results = %#v", i, testCase.owner, testCase.count, len(res.Nfts), res.Nfts)
 			continue
+		}
+		for _, n := range res.Nfts {
+			if n.ClassData != nil {
+				t.Errorf("test case #%02d (owner = %s, ExpandClasses = false): ClassData should be nil. results = %#v", i, testCase.owner, res.Nfts)
+			}
+		}
+		query.ExpandClasses = true
+		res, err = GetNfts(Conn, query, p)
+		if err != nil {
+			t.Errorf("test case #%02d (owner = %s, ExpandClasses = true): GetNfts returned error: %#v", i, testCase.owner, err)
+			continue
+		}
+		if len(res.Nfts) != testCase.count {
+			t.Errorf("test case #%02d (owner = %s, ExpandClasses = true): expect len(res.Nfts) = %d, got %d. results = %#v", i, testCase.owner, testCase.count, len(res.Nfts), res.Nfts)
+			continue
+		}
+		for _, n := range res.Nfts {
+			if n.ClassData == nil {
+				t.Errorf("test case #%02d (owner = %s, ExpandClasses = true): ClassData should not be nil. results = %#v", i, testCase.owner, res.Nfts)
+			}
+			if n.ClassData.Id != n.ClassId {
+				t.Errorf("test case #%02d (owner = %s, ExpandClasses = true): NFT class ID not equal to the ID in expanded class data. results = %#v", i, testCase.owner, res.Nfts)
+				continue
+			}
 		}
 	}
 }

--- a/db/nft_test.go
+++ b/db/nft_test.go
@@ -225,39 +225,42 @@ func TestQueryNftByOwner(t *testing.T) {
 	p := PageRequest{
 		Limit: 10,
 	}
+NEXT_TESTCASE:
 	for i, testCase := range testCases {
 		query := QueryNftRequest{Owner: testCase.owner}
 		res, err := GetNfts(Conn, query, p)
 		if err != nil {
 			t.Errorf("test case #%02d (owner = %s, ExpandClasses = false): GetNfts returned error: %#v", i, testCase.owner, err)
-			continue
+			continue NEXT_TESTCASE
 		}
 		if len(res.Nfts) != testCase.count {
 			t.Errorf("test case #%02d (owner = %s, ExpandClasses = false): expect len(res.Nfts) = %d, got %d. results = %#v", i, testCase.owner, testCase.count, len(res.Nfts), res.Nfts)
-			continue
+			continue NEXT_TESTCASE
 		}
 		for _, n := range res.Nfts {
 			if n.ClassData != nil {
 				t.Errorf("test case #%02d (owner = %s, ExpandClasses = false): ClassData should be nil. results = %#v", i, testCase.owner, res.Nfts)
+				continue NEXT_TESTCASE
 			}
 		}
 		query.ExpandClasses = true
 		res, err = GetNfts(Conn, query, p)
 		if err != nil {
 			t.Errorf("test case #%02d (owner = %s, ExpandClasses = true): GetNfts returned error: %#v", i, testCase.owner, err)
-			continue
+			continue NEXT_TESTCASE
 		}
 		if len(res.Nfts) != testCase.count {
 			t.Errorf("test case #%02d (owner = %s, ExpandClasses = true): expect len(res.Nfts) = %d, got %d. results = %#v", i, testCase.owner, testCase.count, len(res.Nfts), res.Nfts)
-			continue
+			continue NEXT_TESTCASE
 		}
 		for _, n := range res.Nfts {
 			if n.ClassData == nil {
 				t.Errorf("test case #%02d (owner = %s, ExpandClasses = true): ClassData should not be nil. results = %#v", i, testCase.owner, res.Nfts)
+				continue NEXT_TESTCASE
 			}
 			if n.ClassData.Id != n.ClassId {
 				t.Errorf("test case #%02d (owner = %s, ExpandClasses = true): NFT class ID not equal to the ID in expanded class data. results = %#v", i, testCase.owner, res.Nfts)
-				continue
+				continue NEXT_TESTCASE
 			}
 		}
 	}

--- a/db/types.go
+++ b/db/types.go
@@ -203,7 +203,8 @@ type NftClassResponse struct {
 }
 
 type QueryNftRequest struct {
-	Owner string `form:"owner" binding:"required"`
+	Owner         string `form:"owner" binding:"required"`
+	ExpandClasses bool   `form:"expand_classes"`
 }
 
 type QueryNftResponse struct {
@@ -214,7 +215,7 @@ type QueryNftResponse struct {
 type NftResponse struct {
 	Nft
 	ClassParent NftClassParent `json:"class_parent"`
-	ClassData   NftClass       `json:"class_data"`
+	ClassData   *NftClass      `json:"class_data,omitempty"`
 }
 
 type QueryOwnerRequest struct {

--- a/db/types.go
+++ b/db/types.go
@@ -214,6 +214,7 @@ type QueryNftResponse struct {
 type NftResponse struct {
 	Nft
 	ClassParent NftClassParent `json:"class_parent"`
+	ClassData   NftClass       `json:"class_data"`
 }
 
 type QueryOwnerRequest struct {


### PR DESCRIPTION
Added full class data in NFT query response, so caller can get class metadata (and other class info) without calling separate APIs.

(for compatibility reason, the `class_parent` field is kept)

Sample query: `/likechain/likenft/v1/nft?owner=like13f4glvg80zvfrrs7utft5p68pct4mcq7t5atf6&pagination.limit=1`

Before:
```JSON
{
  "pagination": { "next_key": 10065, "count": 1 },
  "nfts": [
    {
      "nft_id": "writing-03a4ec69-a339-4d74-a879-0ee140d5f0fe",
      "class_id": "likenft1jvywpl0f0zndhm6h8sp44esaj88mrkew226wv30ymeq5pnvux4tq760qd7",
      "owner": "like13f4glvg80zvfrrs7utft5p68pct4mcq7t5atf6",
      "uri": "https://api.like.co/likernft/metadata?class_id=likenft1jvywpl0f0zndhm6h8sp44esaj88mrkew226wv30ymeq5pnvux4tq760qd7&nft_id=writing-03a4ec69-a339-4d74-a879-0ee140d5f0fe",
      "uri_hash": "",
      "metadata": {
        "name": "Writing NFT - LikeCoin Chain NFT Module Upgrade, StarFerry Overview",
        "image": "ar://-l7lNA57Vi4jKS7GZHWZppsS-ujoZM7PxWYMyQ6hel8"
      },
      "timestamp": "2022-08-01T02:14:57Z",
      "class_parent": {
        "type": "ISCN",
        "iscn_id_prefix": "iscn://likecoin-chain/uioz4L768qWnVId4uGVnzJqVEXWYo9YBVHAftZNjZWk",
        "account": ""
      }
    }
  ]
}
```

After:
```JSON
{
  "pagination": { "next_key": 10065, "count": 1 },
  "nfts": [
    {
      "nft_id": "writing-03a4ec69-a339-4d74-a879-0ee140d5f0fe",
      "class_id": "likenft1jvywpl0f0zndhm6h8sp44esaj88mrkew226wv30ymeq5pnvux4tq760qd7",
      "owner": "like13f4glvg80zvfrrs7utft5p68pct4mcq7t5atf6",
      "uri": "https://api.like.co/likernft/metadata?class_id=likenft1jvywpl0f0zndhm6h8sp44esaj88mrkew226wv30ymeq5pnvux4tq760qd7&nft_id=writing-03a4ec69-a339-4d74-a879-0ee140d5f0fe",
      "uri_hash": "",
      "metadata": {
        "name": "Writing NFT - LikeCoin Chain NFT Module Upgrade, StarFerry Overview",
        "image": "ar://-l7lNA57Vi4jKS7GZHWZppsS-ujoZM7PxWYMyQ6hel8"
      },
      "timestamp": "2022-08-01T02:14:57Z",
      "class_parent": {
        "type": "ISCN",
        "iscn_id_prefix": "iscn://likecoin-chain/uioz4L768qWnVId4uGVnzJqVEXWYo9YBVHAftZNjZWk",
        "account": ""
      },
      "class_data": {
        "id": "likenft1jvywpl0f0zndhm6h8sp44esaj88mrkew226wv30ymeq5pnvux4tq760qd7",
        "name": "Writing NFT - LikeCoin Chain NFT Module Upgrade, StarFerry Overview",
        "description": "The long-awaited NFT module will be the spotlight in the StarFerry upgrade. This upgrade features the nft module, and nft-related services, such as nft minting, blind box, and marketplace chain API.",
        "symbol": "WRITING",
        "uri": "https://api.like.co/likernft/metadata?iscn_id=iscn%3A%2F%2Flikecoin-chain%2Fuioz4L768qWnVId4uGVnzJqVEXWYo9YBVHAftZNjZWk%2F2",
        "uri_hash": "",
        "config": {
          "burnable": false,
          "max_supply": "0",
          "blind_box_config": null
        },
        "metadata": {
          "url": "https://blog.like.co/en/likecoin-chain-upgrade-starferry-overview/",
          "name": "LikeCoin Chain NFT Module Upgrade, StarFerry Overview",
          "@type": "Article",
          "image": "ar://-l7lNA57Vi4jKS7GZHWZppsS-ujoZM7PxWYMyQ6hel8",
          "version": 1,
          "@context": "http://schema.org/",
          "keywords": "Cosmos,IBC,LikeCoin",
          "usageInfo": "",
          "description": "The long-awaited NFT module will be the spotlight in the StarFerry upgrade. This upgrade features the nft module, and nft-related services, such as nft minting, blind box, and marketplace chain API.",
          "nft_meta_collection_id": "likerland_writing_nft",
          "nft_meta_collection_name": "Writing NFT",
          "nft_meta_collection_descrption": "Writing NFT by Liker Land"
        },
        "parent": {
          "type": "ISCN",
          "iscn_id_prefix": "iscn://likecoin-chain/uioz4L768qWnVId4uGVnzJqVEXWYo9YBVHAftZNjZWk",
          "account": ""
        },
        "price": 0,
        "created_at": "2022-07-29T14:58:54Z"
      }
    }
  ]
}
```