### PR TITLE
Optimize ranking query API

### DIFF
--- a/db/schema/v008.sql
+++ b/db/schema/v008.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_iscn_stakeholders_iscn_pid ON iscn_stakeholders (iscn_pid);


### PR DESCRIPTION
15s -> 0.1s🌚
The root cause is `iscn_stakeholders`:
1. most of the time the left join is not needed;
2. there is no index...
These combined results in full table scan on iscn_stakeholders table in every ranking query...

Building the index seems quite fast (unnoticeable during poller start up)