### PR TITLE
✨ Support query nft events by `creator`

### DIFF
--- a/db/types.go
+++ b/db/types.go
@@ -248,6 +248,7 @@ type QueryEventsRequest struct {
 	IscnIdPrefix   string   `form:"iscn_id_prefix"`
 	Sender         string   `form:"sender"`
 	Receiver       string   `form:"receiver"`
+	Creator        string   `form:"creator"`
 	Verbose        bool     `form:"verbose"`
 	ActionType     []string `form:"action_type"`
 	IgnoreFromList []string `form:"ignore_from_list"`

--- a/rest/nft.go
+++ b/rest/nft.go
@@ -83,8 +83,8 @@ func handleNftEvents(c *gin.Context) {
 		return
 	}
 
-	if form.ClassId == "" && form.IscnIdPrefix == "" && form.Sender == "" && form.Receiver == "" {
-		c.AbortWithStatusJSON(400, gin.H{"error": "must provide either class_id, iscn_id_prefix, sender or receiver"})
+	if form.ClassId == "" && form.IscnIdPrefix == "" && form.Sender == "" && form.Receiver == "" && form.Creator == "" {
+		c.AbortWithStatusJSON(400, gin.H{"error": "must provide either class_id, iscn_id_prefix, sender, receiver or creator"})
 		return
 	}
 	conn := getConn(c)


### PR DESCRIPTION
Currently iscn owner(creator) is not a sender nor receiver in a purchase event (msgSend), so adding a new qs for query