### PR TITLE
🎨 Accept multiple `iscn_owner` for `/class` API

### DIFF
--- a/db/nft.go
+++ b/db/nft.go
@@ -17,7 +17,7 @@ func GetClasses(conn *pgxpool.Conn, q QueryClassRequest, p PageRequest) (QueryCl
 	SELECT DISTINCT ON (c.id)
 		c.id, c.class_id, c.name, c.description, c.symbol,
 		c.uri, c.uri_hash, c.config, c.metadata, c.latest_price,
-		c.parent_type, c.parent_iscn_id_prefix, c.parent_account, c.created_at, c.price_updated_at,
+		c.parent_type, c.parent_iscn_id_prefix, c.parent_account, c.created_at, c.price_updated_at, i.owner,
 	(
 		SELECT array_agg(row_to_json((n.*)))
 		FROM nft as n
@@ -59,7 +59,7 @@ func GetClasses(conn *pgxpool.Conn, q QueryClassRequest, p PageRequest) (QueryCl
 			&res.Pagination.NextKey, &c.Id, &c.Name, &c.Description, &c.Symbol,
 			&c.URI, &c.URIHash, &c.Config, &c.Metadata, &c.LatestPrice,
 			&c.Parent.Type, &c.Parent.IscnIdPrefix, &c.Parent.Account, &c.CreatedAt, &c.PriceUpdatedAt,
-			&nfts,
+			&c.Owner, &nfts,
 		); err != nil {
 			logger.L.Errorw("failed to scan nft class", "error", err)
 			return QueryClassResponse{}, fmt.Errorf("query nft class data failed: %w", err)

--- a/db/nft.go
+++ b/db/nft.go
@@ -12,7 +12,7 @@ import (
 
 func GetClasses(conn *pgxpool.Conn, q QueryClassRequest, p PageRequest) (QueryClassResponse, error) {
 	accountVariations := utils.ConvertAddressPrefixes(q.Account, AddressPrefixes)
-	iscnOwnerVariations := utils.ConvertAddressPrefixes(q.IscnOwner, AddressPrefixes)
+	iscnOwnerVariations := utils.ConvertAddressArrayPrefixes(q.IscnOwner, AddressPrefixes)
 	sql := fmt.Sprintf(`
 	SELECT DISTINCT ON (c.id)
 		c.id, c.class_id, c.name, c.description, c.symbol,

--- a/db/nft_test.go
+++ b/db/nft_test.go
@@ -106,27 +106,27 @@ func TestQueryNftClass(t *testing.T) {
 		{
 			"query by iscn owner 1 (LIKE prefix), AllIscnVersions = true",
 			QueryClassRequest{
-				IscnOwner:       ADDR_01_LIKE,
+				IscnOwner:       []string{ADDR_01_LIKE},
 				AllIscnVersions: true,
 			}, 2, []string{nftClasses[0].Id, nftClasses[1].Id},
 		},
 		{
 			"query by iscn owner 1 (LIKE prefix), AllIscnVersions = false",
 			QueryClassRequest{
-				IscnOwner:       ADDR_01_LIKE,
+				IscnOwner:       []string{ADDR_01_LIKE},
 				AllIscnVersions: false,
 			}, 0, nil,
 		},
 		{
 			"query by iscn owner 2 (LIKE prefix), AllIscnVersions = true",
 			QueryClassRequest{
-				IscnOwner:       ADDR_02_LIKE,
+				IscnOwner:       []string{ADDR_02_LIKE},
 				AllIscnVersions: true,
 			}, 2, []string{nftClasses[0].Id, nftClasses[1].Id},
 		},
 		{
 			"query by iscn owner 3 (LIKE prefix), AllIscnVersions = false",
-			QueryClassRequest{IscnOwner: ADDR_03_LIKE}, 1,
+			QueryClassRequest{IscnOwner: []string{ADDR_03_LIKE}}, 1,
 			[]string{nftClasses[2].Id},
 		},
 		{
@@ -135,7 +135,7 @@ func TestQueryNftClass(t *testing.T) {
 		},
 		{
 			"query by non existing iscn owner",
-			QueryClassRequest{IscnOwner: "nosuchowner"}, 0, nil,
+			QueryClassRequest{IscnOwner: []string{"nosuchowner"}}, 0, nil,
 		},
 	}
 

--- a/db/nft_test.go
+++ b/db/nft_test.go
@@ -137,6 +137,12 @@ func TestQueryNftClass(t *testing.T) {
 			"query by non existing iscn owner",
 			QueryClassRequest{IscnOwner: []string{"nosuchowner"}}, 0, nil,
 		},
+		{
+			"query by multiple iscn owners",
+			QueryClassRequest{
+				IscnOwner: []string{ADDR_02_LIKE, ADDR_03_LIKE},
+			}, 3, []string{nftClasses[0].Id, nftClasses[1].Id, nftClasses[2].Id},
+		},
 	}
 
 	p := PageRequest{

--- a/db/types.go
+++ b/db/types.go
@@ -214,8 +214,9 @@ type QueryClassResponse struct {
 
 type NftClassResponse struct {
 	NftClass
-	Count int   `json:"count,omitempty"`
-	Nfts  []Nft `json:"nfts,omitempty"`
+	Owner string `json:"owner"`
+	Count int    `json:"count,omitempty"`
+	Nfts  []Nft  `json:"nfts,omitempty"`
 }
 
 type QueryNftRequest struct {

--- a/db/types.go
+++ b/db/types.go
@@ -200,11 +200,11 @@ type iscnResponseData struct {
 }
 
 type QueryClassRequest struct {
-	IscnIdPrefix    string `form:"iscn_id_prefix"`
-	Account         string `form:"account"`
-	IscnOwner       string `form:"iscn_owner"`
-	Expand          bool   `form:"expand"`
-	AllIscnVersions bool   `form:"all_iscn_versions"`
+	IscnIdPrefix    string   `form:"iscn_id_prefix"`
+	Account         string   `form:"account"`
+	IscnOwner       []string `form:"iscn_owner"`
+	Expand          bool     `form:"expand"`
+	AllIscnVersions bool     `form:"all_iscn_versions"`
 }
 
 type QueryClassResponse struct {


### PR DESCRIPTION
Not sure if we want to go one step further to turn `Account` to `[]string`, too.