### PR TITLE
✨ Add /classes-owned query for NFT collections

### DIFF
--- a/db/nft_test.go
+++ b/db/nft_test.go
@@ -1386,3 +1386,127 @@ func TestGetCollectorTopRankedCreators(t *testing.T) {
 		}
 	}
 }
+
+func TestQueryClassesOwned(t *testing.T) {
+	defer CleanupTestData(Conn)
+	nftClasses := []NftClass{
+		{
+			Id: "nftlike1aaaaa1",
+		},
+		{
+			Id: "nftlike1bbbbb1",
+		},
+		{
+			Id: "nftlike1ccccc1",
+		},
+	}
+	nfts := []Nft{
+		{
+			NftId:   "testing-nft-109283748",
+			ClassId: nftClasses[0].Id,
+			Owner:   ADDR_01_LIKE,
+		},
+		{
+			NftId:   "testing-nft-109283749",
+			ClassId: nftClasses[0].Id,
+			Owner:   ADDR_02_LIKE,
+		},
+		{
+			NftId:   "testing-nft-109283750",
+			ClassId: nftClasses[1].Id,
+			Owner:   ADDR_03_LIKE,
+		},
+		{
+			NftId:   "testing-nft-109283751",
+			ClassId: nftClasses[1].Id,
+			Owner:   ADDR_01_LIKE,
+		},
+		{
+			NftId:   "testing-nft-109283752",
+			ClassId: nftClasses[2].Id,
+			Owner:   ADDR_01_LIKE,
+		},
+		{
+			NftId:   "testing-nft-109283753",
+			ClassId: nftClasses[2].Id,
+			Owner:   ADDR_02_LIKE,
+		},
+	}
+	InsertTestData(DBTestData{NftClasses: nftClasses, Nfts: nfts})
+
+	testCases := []struct {
+		name     string
+		query    QueryClassesOwnedRequest
+		classIds []string
+	}{
+		{
+			"query owner 01, class IDs (0, 1, 2)",
+			QueryClassesOwnedRequest{
+				ClassIds: []string{nftClasses[0].Id, nftClasses[1].Id, nftClasses[2].Id},
+				Owner:    ADDR_01_LIKE,
+			}, []string{nftClasses[0].Id, nftClasses[1].Id, nftClasses[2].Id},
+		},
+		{
+			"query owner 02, class IDs (0, 1, 2)",
+			QueryClassesOwnedRequest{
+				ClassIds: []string{nftClasses[0].Id, nftClasses[1].Id, nftClasses[2].Id},
+				Owner:    ADDR_02_LIKE,
+			}, []string{nftClasses[0].Id, nftClasses[2].Id},
+		},
+		{
+			"query owner 03, class IDs (0, 1, 2)",
+			QueryClassesOwnedRequest{
+				ClassIds: []string{nftClasses[0].Id, nftClasses[1].Id, nftClasses[2].Id},
+				Owner:    ADDR_03_LIKE,
+			}, []string{nftClasses[1].Id},
+		},
+		{
+			"query owner 01, class IDs (0)",
+			QueryClassesOwnedRequest{
+				ClassIds: []string{nftClasses[0].Id},
+				Owner:    ADDR_01_LIKE,
+			}, []string{nftClasses[0].Id},
+		},
+		{
+			"query owner 02, class IDs (0)",
+			QueryClassesOwnedRequest{
+				ClassIds: []string{nftClasses[0].Id},
+				Owner:    ADDR_02_LIKE,
+			}, []string{nftClasses[0].Id},
+		},
+		{
+			"query owner 03, class IDs (0)",
+			QueryClassesOwnedRequest{
+				ClassIds: []string{nftClasses[0].Id},
+				Owner:    ADDR_03_LIKE,
+			}, []string{},
+		},
+		{
+			"query owner 01, class IDs (0, 1)",
+			QueryClassesOwnedRequest{
+				ClassIds: []string{nftClasses[0].Id, nftClasses[1].Id},
+				Owner:    ADDR_01_LIKE,
+			}, []string{nftClasses[0].Id, nftClasses[1].Id},
+		},
+		{
+			"query owner 02, class IDs (0, 1)",
+			QueryClassesOwnedRequest{
+				ClassIds: []string{nftClasses[0].Id, nftClasses[1].Id},
+				Owner:    ADDR_02_LIKE,
+			}, []string{nftClasses[0].Id},
+		},
+		{
+			"query owner 03, class IDs (0, 1)",
+			QueryClassesOwnedRequest{
+				ClassIds: []string{nftClasses[0].Id, nftClasses[1].Id},
+				Owner:    ADDR_03_LIKE,
+			}, []string{nftClasses[1].Id},
+		},
+	}
+
+	for i, testCase := range testCases {
+		res, err := GetClassesOwned(Conn, testCase.query)
+		require.NoError(t, err, "Error in test case #%02d (%s)", i, testCase.name)
+		require.ElementsMatch(t, res.ClassIds, testCase.classIds, "Error in test case #%02d (%s)", i, testCase.name)
+	}
+}

--- a/db/nft_test.go
+++ b/db/nft_test.go
@@ -1387,7 +1387,7 @@ func TestGetCollectorTopRankedCreators(t *testing.T) {
 	}
 }
 
-func TestQueryClassesOwned(t *testing.T) {
+func TestQueryClassesOwners(t *testing.T) {
 	defer CleanupTestData(Conn)
 	nftClasses := []NftClass{
 		{
@@ -1399,6 +1399,9 @@ func TestQueryClassesOwned(t *testing.T) {
 		{
 			Id: "nftlike1ccccc1",
 		},
+		{
+			Id: "nftlike1ddddd1",
+		},
 	}
 	nfts := []Nft{
 		{
@@ -1409,7 +1412,7 @@ func TestQueryClassesOwned(t *testing.T) {
 		{
 			NftId:   "testing-nft-109283749",
 			ClassId: nftClasses[0].Id,
-			Owner:   ADDR_02_LIKE,
+			Owner:   ADDR_02_COSMOS,
 		},
 		{
 			NftId:   "testing-nft-109283750",
@@ -1429,84 +1432,91 @@ func TestQueryClassesOwned(t *testing.T) {
 		{
 			NftId:   "testing-nft-109283753",
 			ClassId: nftClasses[2].Id,
-			Owner:   ADDR_02_LIKE,
+			Owner:   ADDR_02_COSMOS,
+		},
+		{
+			NftId:   "testing-nft-109283754",
+			ClassId: nftClasses[3].Id,
+			Owner:   "nobody",
 		},
 	}
 	InsertTestData(DBTestData{NftClasses: nftClasses, Nfts: nfts})
 
+	classIds012 := []string{nftClasses[0].Id, nftClasses[1].Id, nftClasses[2].Id}
+	classIds02 := []string{nftClasses[0].Id, nftClasses[2].Id}
+	classIds0 := []string{nftClasses[0].Id}
+	classIds1 := []string{nftClasses[1].Id}
+
 	testCases := []struct {
-		name     string
-		query    QueryClassesOwnedRequest
-		classIds []string
+		name  string
+		query QueryClassesOwnersRequest
+		res   QueryClassesOwnersResponse
 	}{
 		{
-			"query owner 01, class IDs (0, 1, 2)",
-			QueryClassesOwnedRequest{
-				ClassIds: []string{nftClasses[0].Id, nftClasses[1].Id, nftClasses[2].Id},
-				Owner:    ADDR_01_LIKE,
-			}, []string{nftClasses[0].Id, nftClasses[1].Id, nftClasses[2].Id},
+			"class IDs (0, 1, 2) without owners",
+			QueryClassesOwnersRequest{
+				ClassIds: classIds012,
+			},
+			QueryClassesOwnersResponse{
+				Owners: map[string][]string{
+					ADDR_01_LIKE: classIds012,
+					ADDR_02_LIKE: classIds02,
+					ADDR_03_LIKE: classIds1,
+				},
+			},
 		},
 		{
-			"query owner 02, class IDs (0, 1, 2)",
-			QueryClassesOwnedRequest{
-				ClassIds: []string{nftClasses[0].Id, nftClasses[1].Id, nftClasses[2].Id},
-				Owner:    ADDR_02_LIKE,
-			}, []string{nftClasses[0].Id, nftClasses[2].Id},
+			"class IDs (0, 1, 2), owners (01, 02)",
+			QueryClassesOwnersRequest{
+				ClassIds: classIds012,
+				Owners:   []string{ADDR_01_LIKE, ADDR_02_LIKE},
+			},
+			QueryClassesOwnersResponse{
+				Owners: map[string][]string{
+					ADDR_01_LIKE: classIds012,
+					ADDR_02_LIKE: classIds02,
+				},
+			},
 		},
 		{
-			"query owner 03, class IDs (0, 1, 2)",
-			QueryClassesOwnedRequest{
-				ClassIds: []string{nftClasses[0].Id, nftClasses[1].Id, nftClasses[2].Id},
-				Owner:    ADDR_03_LIKE,
-			}, []string{nftClasses[1].Id},
+			"class IDs (0), without owners",
+			QueryClassesOwnersRequest{
+				ClassIds: classIds0,
+			},
+			QueryClassesOwnersResponse{
+				Owners: map[string][]string{
+					ADDR_01_LIKE: classIds0,
+					ADDR_02_LIKE: classIds0,
+				},
+			},
 		},
 		{
-			"query owner 01, class IDs (0)",
-			QueryClassesOwnedRequest{
-				ClassIds: []string{nftClasses[0].Id},
-				Owner:    ADDR_01_LIKE,
-			}, []string{nftClasses[0].Id},
+			"class IDs (0), owners (01, 03)",
+			QueryClassesOwnersRequest{
+				ClassIds: classIds0,
+				Owners:   []string{ADDR_01_LIKE, ADDR_03_LIKE},
+			},
+			QueryClassesOwnersResponse{
+				Owners: map[string][]string{
+					ADDR_01_LIKE: classIds0,
+				},
+			},
 		},
 		{
-			"query owner 02, class IDs (0)",
-			QueryClassesOwnedRequest{
-				ClassIds: []string{nftClasses[0].Id},
-				Owner:    ADDR_02_LIKE,
-			}, []string{nftClasses[0].Id},
-		},
-		{
-			"query owner 03, class IDs (0)",
-			QueryClassesOwnedRequest{
-				ClassIds: []string{nftClasses[0].Id},
-				Owner:    ADDR_03_LIKE,
-			}, []string{},
-		},
-		{
-			"query owner 01, class IDs (0, 1)",
-			QueryClassesOwnedRequest{
-				ClassIds: []string{nftClasses[0].Id, nftClasses[1].Id},
-				Owner:    ADDR_01_LIKE,
-			}, []string{nftClasses[0].Id, nftClasses[1].Id},
-		},
-		{
-			"query owner 02, class IDs (0, 1)",
-			QueryClassesOwnedRequest{
-				ClassIds: []string{nftClasses[0].Id, nftClasses[1].Id},
-				Owner:    ADDR_02_LIKE,
-			}, []string{nftClasses[0].Id},
-		},
-		{
-			"query owner 03, class IDs (0, 1)",
-			QueryClassesOwnedRequest{
-				ClassIds: []string{nftClasses[0].Id, nftClasses[1].Id},
-				Owner:    ADDR_03_LIKE,
-			}, []string{nftClasses[1].Id},
+			"class IDs (3), owners (01, 02, 03)",
+			QueryClassesOwnersRequest{
+				ClassIds: []string{nftClasses[3].Id},
+				Owners:   []string{ADDR_01_LIKE, ADDR_02_LIKE, ADDR_03_LIKE},
+			},
+			QueryClassesOwnersResponse{
+				Owners: map[string][]string{},
+			},
 		},
 	}
 
 	for i, testCase := range testCases {
-		res, err := GetClassesOwned(Conn, testCase.query)
+		res, err := GetClassesOwners(Conn, testCase.query)
 		require.NoError(t, err, "Error in test case #%02d (%s)", i, testCase.name)
-		require.ElementsMatch(t, res.ClassIds, testCase.classIds, "Error in test case #%02d (%s)", i, testCase.name)
+		require.Equal(t, testCase.res, res, "Error in test case #%02d (%s)", i, testCase.name)
 	}
 }

--- a/db/types.go
+++ b/db/types.go
@@ -413,3 +413,12 @@ type CollectorTopRankedCreator struct {
 type QueryCollectorTopRankedCreatorsResponse struct {
 	Creators []CollectorTopRankedCreator `json:"creators"`
 }
+
+type QueryClassesOwnedRequest struct {
+	Owner    string   `form:"owner" binding:"required"`
+	ClassIds []string `form:"class_ids" binding:"required"`
+}
+
+type QueryClassesOwnedResponse struct {
+	ClassIds []string `json:"class_ids"`
+}

--- a/db/types.go
+++ b/db/types.go
@@ -414,11 +414,12 @@ type QueryCollectorTopRankedCreatorsResponse struct {
 	Creators []CollectorTopRankedCreator `json:"creators"`
 }
 
-type QueryClassesOwnedRequest struct {
-	Owner    string   `form:"owner" binding:"required"`
+type QueryClassesOwnersRequest struct {
 	ClassIds []string `form:"class_ids" binding:"required"`
+	Owners   []string `form:"owners"`
 }
 
-type QueryClassesOwnedResponse struct {
-	ClassIds []string `json:"class_ids"`
+type QueryClassesOwnersResponse struct {
+	// key: owner address, value: class IDs
+	Owners map[string][]string `json:"owners"`
 }

--- a/rest/nft.go
+++ b/rest/nft.go
@@ -231,3 +231,19 @@ func handleNftCollectorTopRankedCreatorsRequest(c *gin.Context) {
 
 	c.JSON(200, res)
 }
+
+func handleClassesOwnedRequest(c *gin.Context) {
+	var form db.QueryClassesOwnedRequest
+	if err := c.ShouldBindQuery(&form); err != nil {
+		c.AbortWithStatusJSON(400, gin.H{"error": "invalid inputs: " + err.Error()})
+		return
+	}
+	conn := getConn(c)
+	res, err := db.GetClassesOwned(conn, form)
+	if err != nil {
+		c.AbortWithStatusJSON(500, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(200, res)
+}

--- a/rest/nft.go
+++ b/rest/nft.go
@@ -232,14 +232,14 @@ func handleNftCollectorTopRankedCreatorsRequest(c *gin.Context) {
 	c.JSON(200, res)
 }
 
-func handleClassesOwnedRequest(c *gin.Context) {
-	var form db.QueryClassesOwnedRequest
+func handleClassesOwnersRequest(c *gin.Context) {
+	var form db.QueryClassesOwnersRequest
 	if err := c.ShouldBindQuery(&form); err != nil {
 		c.AbortWithStatusJSON(400, gin.H{"error": "invalid inputs: " + err.Error()})
 		return
 	}
 	conn := getConn(c)
-	res, err := db.GetClassesOwned(conn, form)
+	res, err := db.GetClassesOwners(conn, form)
 	if err != nil {
 		c.AbortWithStatusJSON(500, gin.H{"error": err.Error()})
 		return

--- a/rest/nft_test.go
+++ b/rest/nft_test.go
@@ -1,0 +1,172 @@
+package rest_test
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	. "github.com/likecoin/likecoin-chain-tx-indexer/db"
+	"github.com/likecoin/likecoin-chain-tx-indexer/rest"
+	. "github.com/likecoin/likecoin-chain-tx-indexer/test"
+)
+
+func TestQueryClassesOwners(t *testing.T) {
+	defer CleanupTestData(Conn)
+	nftClasses := []NftClass{
+		{
+			Id: "nftlike1aaaaa1",
+		},
+		{
+			Id: "nftlike1bbbbb1",
+		},
+		{
+			Id: "nftlike1ccccc1",
+		},
+		{
+			Id: "nftlike1ddddd1",
+		},
+	}
+	nfts := []Nft{
+		{
+			NftId:   "testing-nft-109283748",
+			ClassId: nftClasses[0].Id,
+			Owner:   ADDR_01_LIKE,
+		},
+		{
+			NftId:   "testing-nft-109283749",
+			ClassId: nftClasses[0].Id,
+			Owner:   ADDR_02_COSMOS,
+		},
+		{
+			NftId:   "testing-nft-109283750",
+			ClassId: nftClasses[1].Id,
+			Owner:   ADDR_03_LIKE,
+		},
+		{
+			NftId:   "testing-nft-109283751",
+			ClassId: nftClasses[1].Id,
+			Owner:   ADDR_01_LIKE,
+		},
+		{
+			NftId:   "testing-nft-109283752",
+			ClassId: nftClasses[2].Id,
+			Owner:   ADDR_01_LIKE,
+		},
+		{
+			NftId:   "testing-nft-109283753",
+			ClassId: nftClasses[2].Id,
+			Owner:   ADDR_02_COSMOS,
+		},
+		{
+			NftId:   "testing-nft-109283754",
+			ClassId: nftClasses[3].Id,
+			Owner:   "nobody",
+		},
+	}
+	InsertTestData(DBTestData{NftClasses: nftClasses, Nfts: nfts})
+
+	classIds012 := []string{nftClasses[0].Id, nftClasses[1].Id, nftClasses[2].Id}
+	classIds02 := []string{nftClasses[0].Id, nftClasses[2].Id}
+	classIds0 := []string{nftClasses[0].Id}
+	classIds1 := []string{nftClasses[1].Id}
+
+	testCases := []struct {
+		name  string
+		query QueryClassesOwnersRequest
+		res   QueryClassesOwnersResponse
+	}{
+		{
+			"class IDs (0, 1, 2) without owners",
+			QueryClassesOwnersRequest{
+				ClassIds: classIds012,
+			},
+			QueryClassesOwnersResponse{
+				Owners: map[string][]string{
+					ADDR_01_LIKE: classIds012,
+					ADDR_02_LIKE: classIds02,
+					ADDR_03_LIKE: classIds1,
+				},
+			},
+		},
+		{
+			"class IDs (0, 1, 2), owners (01, 02)",
+			QueryClassesOwnersRequest{
+				ClassIds: classIds012,
+				Owners:   []string{ADDR_01_LIKE, ADDR_02_LIKE},
+			},
+			QueryClassesOwnersResponse{
+				Owners: map[string][]string{
+					ADDR_01_LIKE: classIds012,
+					ADDR_02_LIKE: classIds02,
+				},
+			},
+		},
+		{
+			"class IDs (0), without owners",
+			QueryClassesOwnersRequest{
+				ClassIds: classIds0,
+			},
+			QueryClassesOwnersResponse{
+				Owners: map[string][]string{
+					ADDR_01_LIKE: classIds0,
+					ADDR_02_LIKE: classIds0,
+				},
+			},
+		},
+		{
+			"class IDs (0), owners (01, 03)",
+			QueryClassesOwnersRequest{
+				ClassIds: classIds0,
+				Owners:   []string{ADDR_01_LIKE, ADDR_03_LIKE},
+			},
+			QueryClassesOwnersResponse{
+				Owners: map[string][]string{
+					ADDR_01_LIKE: classIds0,
+				},
+			},
+		},
+		{
+			"class IDs (3), owners (01, 02, 03)",
+			QueryClassesOwnersRequest{
+				ClassIds: []string{nftClasses[3].Id},
+				Owners:   []string{ADDR_01_LIKE, ADDR_02_LIKE, ADDR_03_LIKE},
+			},
+			QueryClassesOwnersResponse{
+				Owners: map[string][]string{},
+			},
+		},
+	}
+
+	for i, testCase := range testCases {
+		query := rest.NFT_ENDPOINT + "/classes-owners?"
+		for _, classId := range testCase.query.ClassIds {
+			query += "class_ids=" + classId + "&"
+		}
+		for _, owner := range testCase.query.Owners {
+			query += "owners=" + owner + "&"
+		}
+		req := httptest.NewRequest("GET", query, nil)
+		httpRes, body := request(req)
+		require.Equal(t, 200, httpRes.StatusCode, "Error in test case #%02d (%s), query = `%s`, response = `%s`", i, testCase.name, testCase.query, body)
+		var res QueryClassesOwnersResponse
+		err := json.Unmarshal([]byte(body), &res)
+		require.NoError(t, err, "Error in test case #%02d (%s), query = `%s` response = `%s`", i, testCase.name, testCase.query, body)
+		require.Equal(t, testCase.res, res, "Error in test case #%02d (%s), query = `%s`, response = `%s`", i, testCase.name, testCase.query, body)
+	}
+
+	req := httptest.NewRequest(
+		"GET",
+		rest.NFT_ENDPOINT+"/classes-owners?owners="+ADDR_01_LIKE,
+		nil,
+	)
+	httpRes, body := request(req)
+	require.Equal(t, 400, httpRes.StatusCode)
+	var res struct {
+		Err string `json:"error"`
+	}
+	err := json.Unmarshal([]byte(body), &res)
+	require.NoError(t, err)
+	require.Contains(t, res.Err, "Field validation for 'ClassIds' failed on the 'required' tag")
+}

--- a/rest/router.go
+++ b/rest/router.go
@@ -47,7 +47,7 @@ func GetRouter(pool *pgxpool.Pool, defaultApiAddresses []string) *gin.Engine {
 		nft.GET("/user-stat", handleNftUserStat)
 		nft.GET("/marketplace", handleNftMarketplaceItem)
 		nft.GET("/collector-top-ranked-creators", handleNftCollectorTopRankedCreatorsRequest)
-		nft.GET("/classes-owned", handleClassesOwnedRequest)
+		nft.GET("/classes-owners", handleClassesOwnersRequest)
 	}
 	analysis := router.Group(ANALYSIS_ENDPOINT)
 	{

--- a/rest/router.go
+++ b/rest/router.go
@@ -47,6 +47,7 @@ func GetRouter(pool *pgxpool.Pool, defaultApiAddresses []string) *gin.Engine {
 		nft.GET("/user-stat", handleNftUserStat)
 		nft.GET("/marketplace", handleNftMarketplaceItem)
 		nft.GET("/collector-top-ranked-creators", handleNftCollectorTopRankedCreatorsRequest)
+		nft.GET("/classes-owned", handleClassesOwnedRequest)
 	}
 	analysis := router.Group(ANALYSIS_ENDPOINT)
 	{


### PR DESCRIPTION
Example:
`GET /likechain/likenft/v1/classes-owned?class_ids=nftlike1aaaaa1&class_ids=nftlike1bbbbb1&class_ids=nftlike1ccccc1&owner=like1abcd`

Response:
```
{
  "class_ids": [
    "nftlike1aaaaa1",
    "nftlike1bbbbb1"
  ]
}
```
Which means `like1abcd` owns some NFTs with classes `nftlike1aaaaa1` and `nftlike1bbbbb1` but not `nftlike1ccccc1`.

(TODO: if a collection is large, will it be too big for a GET request URL?)