### PR TITLE
🐛 Fix no time zone time parse error

### DIFF
--- a/db/types.go
+++ b/db/types.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"encoding/json"
+	"strings"
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/types"
@@ -93,6 +94,21 @@ type NftClassParent struct {
 	Account      string `json:"account"`
 }
 
+type NoTimeZoneTime struct {
+	time.Time
+}
+
+const noTimeZoneTimeLayout = "2006-01-02T15:04:05"
+
+func (ntzt *NoTimeZoneTime) UnmarshalJSON(b []byte) error {
+	t, err := time.Parse(noTimeZoneTimeLayout, strings.Trim(string(b), "\""))
+	if err != nil {
+		return err
+	}
+	ntzt.Time = t
+	return nil
+}
+
 type Nft struct {
 	NftId          string          `json:"nft_id"`
 	ClassId        string          `json:"class_id"`
@@ -102,7 +118,7 @@ type Nft struct {
 	Metadata       json.RawMessage `json:"metadata"`
 	Timestamp      time.Time       `json:"timestamp"`
 	LatestPrice    uint64          `json:"latest_price,omitempty"`
-	PriceUpdatedAt *time.Time      `json:"price_updated_at,omitempty"`
+	PriceUpdatedAt *NoTimeZoneTime `json:"price_updated_at,omitempty"`
 }
 
 type NftEventAction string

--- a/db/types.go
+++ b/db/types.go
@@ -98,10 +98,10 @@ type NoTimeZoneTime struct {
 	time.Time
 }
 
-const noTimeZoneTimeLayout = "2006-01-02T15:04:05"
+const NoTimeZoneTimeLayout = "2006-01-02T15:04:05"
 
 func (ntzt *NoTimeZoneTime) UnmarshalJSON(b []byte) error {
-	t, err := time.Parse(noTimeZoneTimeLayout, strings.Trim(string(b), "\""))
+	t, err := time.Parse(NoTimeZoneTimeLayout, strings.Trim(string(b), "\""))
 	if err != nil {
 		return err
 	}

--- a/db/types_test.go
+++ b/db/types_test.go
@@ -1,0 +1,26 @@
+package db_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/likecoin/likecoin-chain-tx-indexer/db"
+	"github.com/stretchr/testify/require"
+)
+
+type TestStruct struct {
+	MyTime db.NoTimeZoneTime `json:"my_time"`
+}
+
+func TestNoTimeZoneTimeUnmarshalJSON(t *testing.T) {
+	timeString := "2023-07-12T12:34:56"
+	testJson := fmt.Sprintf(`{"my_time": "%s"}`, timeString)
+	var ts TestStruct
+	if err := json.Unmarshal([]byte(testJson), &ts); err != nil {
+		t.Errorf("Error: %v", err)
+	}
+	expectedTime, _ := time.Parse(db.NoTimeZoneTimeLayout, timeString)
+	require.Equal(t, expectedTime, ts.MyTime.Time)
+}


### PR DESCRIPTION
Currently only apply `NoTimeZoneTime` type on `Nft.PriceUpdatedAt`. Not sure if it's necessary to apply on all `timestamp without time zone` fields.

<img width="776" alt="截圖 2023-07-12 下午12 28 27" src="https://github.com/likecoin/likecoin-chain-tx-indexer/assets/33746295/40d94353-d281-4547-91ed-24499da9e38c">
